### PR TITLE
Fix empty sequence error when showing help with no options (only flags)

### DIFF
--- a/ArgsParser.Example/Program.cs
+++ b/ArgsParser.Example/Program.cs
@@ -4,45 +4,58 @@ namespace ArgsParser.Example
     {
         static void Main(string[] args)
         {
-            // Force example arguments.
-            args = new string[] { "-serve", "-from", "15 APR 1980 GMT", "-verbose", "9999", "-write", "../output" };
-
-            Console.WriteLine();
-            Console.WriteLine("EXAMPLE APPLICATION");
-
-            // Define the options and flags, including whether required and any default values.
+            Parser? parser = null;
             var indent = 2;
-            var now = DateTime.Now.ToString("s");
-            var parser = new Parser(args)
-              .SupportsOption<int>("port", "Port to start the dev server on", 1337)    // Optional, with default.
-              .RequiresOption<string>("read", "Folder to read the site from", "site")  // Required, with default.
-              .RequiresOption<string>("write", "CSV file to write the result to")      // Required, no default.
-              .RequiresOption<DateTime>("from", "Earliest date/time", "01 JAN 1980")   // Required, with default.
-              .SupportsFlag("serve", "Start the site going in a dev server")           // Optional flag.
-              .SupportsFlag("force", "Overwrite any destination content")              // Optional flag.
-              .AddCustomValidator("write", IsCSV)  // Automatic extra check.
-              .ShowHelpLegend(true)  // Include explanatory notes in Help text?
-              .AddExtraHelp(
-                  "Notes:",
-                  "Specifying a port does nothing without adding the -serve flag.",
-                  "Choosing -force is potentially destructive!")
-              .Help(indent, "Usage:")  // Show instructions to the user.
-              .Parse()  // Check the provided input arguments.
-              .ShowProvided(indent, "Provided:");  // Summarise the provided options and flags.
 
-            // Show any errors, and abort.
-            if (parser.HasErrors)
+            try
             {
-                parser.ShowErrors(indent, "Issues:");
+                // Force example arguments.
+                args = new string[] { "-serve", "-from", "15 APR 1980 GMT", "-verbose", "9999", "-write", "../output" };
+
                 Console.WriteLine();
-                return;
+                Console.WriteLine("EXAMPLE APPLICATION");
+
+                // Define the options and flags, including whether required and any default values.
+                var now = DateTime.Now.ToString("s");
+                parser = new Parser(args)
+                  .SupportsOption<int>("port", "Port to start the dev server on", 1337)    // Optional, with default.
+                  .RequiresOption<string>("read", "Folder to read the site from", "site")  // Required, with default.
+                  .RequiresOption<string>("write", "CSV file to write the result to")      // Required, no default.
+                  .RequiresOption<DateTime>("from", "Earliest date/time", "01 JAN 1980")   // Required, with default.
+                  .SupportsFlag("serve", "Start the site going in a dev server")           // Optional flag.
+                  .SupportsFlag("force", "Overwrite any destination content")              // Optional flag.
+                  .AddCustomValidator("write", IsCSV)  // Automatic extra check.
+                  .ShowHelpLegend(true)  // Include explanatory notes in Help text?
+                  .AddExtraHelp(
+                      "Notes:",
+                      "Specifying a port does nothing without adding the -serve flag.",
+                      "Choosing -force is potentially destructive!")
+                  .Help(indent, "Usage:")  // Show instructions to the user.
+                  .Parse()  // Check the provided input arguments.
+                  .ShowProvided(indent, "Provided:");  // Summarise the provided options and flags.
+
+                // Show any errors, and abort.
+                if (parser.HasErrors) throw new ApplicationException();
+
+                // Examples of accessing the options/flags.
+                var shouldServe = parser.IsFlagProvided("serve");
+                var port = parser.GetOption<int>("port");
+                var readFromFolder = parser.GetOption<string>("read");
+                var writeToFolder = parser.GetOption<string>("write");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine();
+                parser!.ShowErrors(indent, "Issues:");
+                Console.WriteLine();
             }
 
-            // Examples of accessing the options/flags.
-            var shouldServe = parser.IsFlagProvided("serve");
-            var port = parser.GetOption<int>("port");
-            var readFromFolder = parser.GetOption<string>("read");
-            var writeToFolder = parser.GetOption<string>("write");
+            // For the avoidance of confusion.
+            Console.WriteLine();
+            Console.WriteLine("IMPORTANT NOTE");
+            Console.WriteLine("The arguments in this example are hard-coded into the program.");
+            Console.WriteLine("It DOES NOT look at what you pass in on the command line.");
+            Console.WriteLine();
         }
 
         /// <summary>Sample validator function which checks for a CSV filename.</summary>

--- a/ArgsParser.Tests/ParserTests.cs
+++ b/ArgsParser.Tests/ParserTests.cs
@@ -49,6 +49,41 @@ namespace ArgsParser.Tests
             Assert.IsFalse(result.HasErrors);
         }
 
+        [Test]
+        public void NothingAllowed_NothingProvided_ShowHelp_DoesNotThrow()
+        {
+            var parser = new Parser(new string[] { })
+                .Parse();
+
+            TestDelegate action = new(() => parser.Help());
+
+            Assert.DoesNotThrow(action);
+        }
+
+        [Test]
+        public void OnlyOptions_ShowHelp_DoesNotThrow()
+        {
+            var parser = new Parser(new string[] { })
+                .SupportsOption<string>("opt", "An option")
+                .Parse();
+
+            TestDelegate action = new(() => parser.Help());
+
+            Assert.DoesNotThrow(action);
+        }
+
+        [Test]
+        public void OnlyFlags_ShowHelp_DoesNotThrow()
+        {
+            var parser = new Parser(new string[] { })
+                .SupportsFlag("flag","A flag")
+                .Parse();
+
+            TestDelegate action = new(() => parser.Help());
+
+            Assert.DoesNotThrow(action);
+        }
+
         /* OPTIONS */
 
         [Test]

--- a/ArgsParser/ArgsParser.csproj
+++ b/ArgsParser/ArgsParser.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>args, parsing</PackageTags>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>6.1.0</Version>
+    <Version>6.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ArgsParser/Parser.cs
+++ b/ArgsParser/Parser.cs
@@ -294,7 +294,7 @@ namespace ArgsParser
             var pad = "".PadLeft(indent);
             var req = "*";
             var width = Math.Max(maxOptionWidth, maxFlagWidth);
-            var typeWidth = knownOptions.Max(x => x.ArgTypeName.Length);
+            var typeWidth = knownOptions.Any() ? knownOptions.Max(x => x.ArgTypeName.Length) : 0;
             var flagWidth = width + (knownOptions.Any() ? typeWidth + 2 : 0);
 
             if (heading.Any())

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Available as a [nuget package](https://www.nuget.org/packages/ArgsParser/).
 - [Getting the Provided Options and Flags](#getting-the-provided-options-and-flags)
 - [Checking for Errors Manually](#checking-for-errors-manually)
 - [Examples of Argument Errors](#examples-of-argument-errors)
+- [Running the Tests](#running-the-tests)
 
 ## What the User Sees
 
@@ -380,6 +381,12 @@ Based on the example above the errors (as key/value pairs) will be as follows:
     - This is unexpected because `run` was not recognised as a valid option
   - `4` => `-ignore is an unknown flag`
     - This is assumed to be a flag because it is followed by `-port` rather than a value
+
+## Running the Tests
+
+Normally you'd just do `dotnet test` at the top folder in the terminal/command prompt.
+
+Unfortunately the test runner treats console output as a *Warning*, and the tests that hit the `.Help()` method generate console output.  To suppress that you can use `dotnet test -- NUnit.ConsoleOut=0` instead.
 
 ---
 


### PR DESCRIPTION
The initial use case was for options, and whilst the assumption that options will always be present was dropped when flags were added there is still a bit of code that was missed.

The help display calculates the width of things in order to visually line up the help text columns for name, type etc.  The calculation didn't check for options being omitted, then ran a max to get the biggest and blew up as max was running over an empty collection.

This PR introduces a check (and default value) plus unit tests.